### PR TITLE
Make portage_utils.py work with both python 2.7 and 3

### DIFF
--- a/bin/filter-parallel.py
+++ b/bin/filter-parallel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 # @file filter-parallel.py
 # @brief Filter lines in parallel from multiple line-aligned files according to
@@ -12,21 +12,17 @@
 # Copyright 2015, Sa Majeste la Reine du Chef du Canada /
 # Copyright 2015, Her Majesty in Right of Canada
 
-from __future__ import print_function, unicode_literals, division, absolute_import
-
 import sys
 import os.path
 from argparse import ArgumentParser, FileType, Action
 
-# If this script is run from within src/ rather than from the installed bin
-# directory, we add src/utils to the Python module include path (sys.path)
-# to arrange that portage_utils will be imported from src/utils.
-if sys.argv[0] not in ('', '-c'):
-   bin_path = os.path.dirname(sys.argv[0])
-   if os.path.basename(bin_path) != "bin":
-      sys.path.insert(1, os.path.normpath(os.path.join(bin_path, "..", "utils")))
-
-from portage_utils import *
+from portage_utils import (
+   open,
+   printCopyright,
+   DebugAction,
+   HelpAction,
+   VerboseAction,
+)
 
 
 class Op(object):

--- a/bin/strip-parallel-blank-lines.py
+++ b/bin/strip-parallel-blank-lines.py
@@ -18,13 +18,9 @@
 import sys
 import re
 
-# portage_utils provides a bunch of useful and handy functions, including:
-#   HelpAction, VerboseAction, DebugAction (helpers for argument processing)
-#   printCopyright
-#   info, verbose, debug, warn, error, fatal_error
+# portage_utils provides for us:
 #   open (transparently open stdin, stdout, plain text files, compressed files or pipes)
-from portage_utils import *
-
+from portage_utils import open
 
 help = """
 strip-parallel-blank-lines.py [-r] file1 [file2 file3...]
@@ -49,16 +45,16 @@ if len(args) > 1 and args[0] == "-r":
     args = args[1:]
 
 if len(args) < 1 or args[0] == "-h":
-    sys.stderr.write(help);
+    sys.stderr.write(help)
     sys.exit(1)
 
-blankline = re.compile("^\s*$")
+blankline = re.compile(r"^\s*$")
 
 ifiles = []
 ofiles = []
 for file in args:
-    ifiles.append(open(file, "rt", encoding="utf8"))
-    ofiles.append(open(re.sub(r'(.gz$|$)', r'.no-blanks\g<1>', file, count=1), "wt"))
+    ifiles.append(open(file, "r"))
+    ofiles.append(open(re.sub(r'(.gz$|$)', r'.no-blanks\g<1>', file, count=1), "w"))
 
 second = 1
 if len(ifiles) < 2: second = 0          # only use file1 if only file1 given
@@ -74,15 +70,15 @@ for lines[0] in ifiles[0]:
 
     if replace:
         rep = blankline.match(lines[0])
-        for i in range(0,len(ifiles)):
+        for i in range(0, len(ifiles)):
             if rep and blankline.match(lines[i]): lines[i] = ".\n"
             ofiles[i].write(lines[i])
     else:
         if not blankline.match(lines[0]) and not blankline.match(lines[second]):
-            for i in range(0,len(ifiles)):
+            for i in range(0, len(ifiles)):
                 ofiles[i].write(lines[i])
 
 for file in ifiles:
-    if (file.readline() != ""):
-        sys.stderr.write("file " + file.name + " too long!\n");
+    if file.readline() != "":
+        sys.stderr.write("file " + file.name + " too long!\n")
         sys.exit(1)

--- a/bin/strip-parallel-blank-lines.py
+++ b/bin/strip-parallel-blank-lines.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 # @file strip-parallel-blank-lines.py
 # @brief Strip blank lines in parallel from one or more line-aligned files:
@@ -17,15 +17,6 @@
 
 import sys
 import re
-
-# If this script is run from within src/ rather than from the installed bin
-# directory, we add src/utils to the Python module include path (sys.path)
-# to arrange that portage_utils will be imported from src/utils.
-import os.path
-if sys.argv[0] not in ('', '-c'):
-   bin_path = os.path.dirname(sys.argv[0])
-   if os.path.basename(bin_path) != "bin":
-      sys.path.insert(1, os.path.normpath(os.path.join(bin_path, "..", "utils")))
 
 # portage_utils provides a bunch of useful and handy functions, including:
 #   HelpAction, VerboseAction, DebugAction (helpers for argument processing)
@@ -66,8 +57,8 @@ blankline = re.compile("^\s*$")
 ifiles = []
 ofiles = []
 for file in args:
-    ifiles.append(open(file, "r"))
-    ofiles.append(open(re.sub(r'(.gz$|$)', r'.no-blanks\g<1>', file), "w"))
+    ifiles.append(open(file, "rt", encoding="utf8"))
+    ofiles.append(open(re.sub(r'(.gz$|$)', r'.no-blanks\g<1>', file, count=1), "wt"))
 
 second = 1
 if len(ifiles) < 2: second = 0          # only use file1 if only file1 given

--- a/bin/strip-parallel-duplicates.py
+++ b/bin/strip-parallel-duplicates.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python2
-# $Id: prog.py,v 1.3 2012/05/15 20:36:59 joanise Exp $
+#!/usr/bin/env python3
 
 # @file strip-parallel-duplicates.py
 # @brief Strip lines in parallel from multiple line-aligned files if the lines
@@ -13,28 +12,23 @@
 # Copyright 2012, Sa Majeste la Reine du Chef du Canada /
 # Copyright 2012, Her Majesty in Right of Canada
 
-from __future__ import print_function, unicode_literals, division, absolute_import
-
-import sys
-import os.path
 from argparse import ArgumentParser, FileType
 
-# If this script is run from within src/ rather than from the installed bin
-# directory, we add src/utils to the Python module include path (sys.path)
-# to arrange that portage_utils will be imported from src/utils.
-if sys.argv[0] not in ('', '-c'):
-   bin_path = os.path.dirname(sys.argv[0])
-   if os.path.basename(bin_path) != "bin":
-      sys.path.insert(1, os.path.normpath(os.path.join(bin_path, "..", "utils")))
-
-from portage_utils import *
+from portage_utils import (
+    open,
+    fatal_error,
+    printCopyright,
+    DebugAction,
+    HelpAction,
+    VerboseAction,
+)
 
 
 def get_args():
    """Command line argument processing."""
 
-   usage="strip-parallel-duplicates.py [options] file1 file2 [file3 ...]"
-   help="""
+   usage = "strip-parallel-duplicates.py [options] file1 file2 [file3 ...]"
+   help = """
    Strip lines in parallel from multiple line-aligned files if the lines
    from the compared files are identical. Write output to <file*><ext>, where
    <ext> defaults to .dedup.
@@ -68,7 +62,7 @@ def get_args():
    return cmd_args
 
 def main():
-   printCopyright("strip-parallel-duplicates.py", 2012);
+   printCopyright("strip-parallel-duplicates.py", 2012)
 
    cmd_args = get_args()
    out_files = tuple(open(f.name+cmd_args.ext, 'w') for f in cmd_args.in_files)
@@ -78,7 +72,7 @@ def main():
       lines = []
       for f in cmd_args.in_files:
          lines.append(f.readline())
-         if len(lines[-1]) is 0: eof = True
+         if len(lines[-1]) == 0: eof = True
       if eof: break
       for i in range(1, cmd_args.compare):
          if lines[i] != lines[0]: identical = False; break

--- a/lib/portage_utils.py
+++ b/lib/portage_utils.py
@@ -168,7 +168,8 @@ def open(filename, mode='r', quiet=True, encoding="utf8"):
    encoding: defaults to "utf8" for text modes (Python 3 only; ignored in Python 2.7)
    return: file handle to the open file.
    """
-   if mode in ("rb", "wb"):
+
+   if "b" in mode:
       # you cannot open a file in binary mode with an encoding in Python 3
       encoding = None
 

--- a/lib/portage_utils.py
+++ b/lib/portage_utils.py
@@ -199,7 +199,7 @@ def open(filename, mode='r', quiet=True, encoding="utf8"):
                             stderr=open('/dev/null', 'w')).stdout
          else:
             theFile = Popen(["zcat", "-f", filename], stdout=PIPE, encoding=encoding).stdout
-      elif mode in ('w', 'wt', 'rb'):
+      elif mode in ('w', 'wt', 'wb'):
          internal_file = builtin_open(filename, mode, encoding=encoding)
          theFile = Popen(["gzip"], close_fds=True, stdin=PIPE, encoding=encoding,
                          stdout=internal_file).stdin

--- a/tests/basics/Makefile
+++ b/tests/basics/Makefile
@@ -17,7 +17,7 @@
 # Copyright 2021, Her Majesty in Right of Canada
 
 include ../Makefile.incl
-TEMP_FILES=out.* src/parallel*.no-blanks src/parallel*.dedup \
+TEMP_FILES=out.* in-copy.* src/parallel*.no-blanks src/parallel*.dedup \
            src/parallel*.filt src/parallel*.uniq seq.gz
 TEMP_DIRS=
 SHELL:=/bin/bash
@@ -84,6 +84,13 @@ test: compare.out.strip-blanks
 out.strip-blanks: src/parallel1 src/parallel2
 	strip-parallel-blank-lines.py $+
 	head src/parallel?.no-blanks > $@
+
+test: compare.out.strip-blanks-r
+out.strip-blanks-r: src/parallel1 src/parallel2
+	cp src/parallel1 in-copy.parallel1
+	gzip < src/parallel2 > in-copy.parallel2.gz
+	strip-parallel-blank-lines.py -r in-copy.parallel1 in-copy.parallel2.gz
+	zcat -f in-copy.parallel?.no-blanks* > $@
 
 test: compare.out.strip-dup
 out.strip-dup: src/parallel1 src/parallel2

--- a/tests/basics/Makefile
+++ b/tests/basics/Makefile
@@ -121,3 +121,8 @@ test.lines.py:
 	seq 1 20 | gzip > seq.gz
 	diff <(lines.py <(echo $$'2\n4\n4\n10\n1') seq.gz) <(echo $$'1\n2\n4\n4\n10')
 
+test: test.select-lines.py
+test.select-lines.py:
+	diff <(select-lines.py <(echo $$'2\n4\n5\n10') <(seq 1 20)) <(echo $$'2\n4\n5\n10')
+	! select-lines.py <(echo $$'2\n4\n3\n10') <(seq 1 20) >& /dev/null
+	! select-lines.py <(echo not-a-number) <(seq 1 20) >& /dev/null

--- a/tests/basics/ref/out.strip-blanks-r
+++ b/tests/basics/ref/out.strip-blanks-r
@@ -1,0 +1,12 @@
+asdf
+qwer
+.
+zxcv
+asdf
+zxcv
+Asdf
+
+Qwer
+Zxcv
+asdf
+Zxcv

--- a/tests/check-installation/Makefile
+++ b/tests/check-installation/Makefile
@@ -63,7 +63,7 @@ perl_version:
 
 .PHONY: perl_modules
 perl_modules:
-	@rc=0; for module in XML::Twig XML::XPath File::Temp Getopt::Long POSIX File::Basename Data::Dumper locale; do \
+	@rc=0; for module in XML::Twig XML::XPath XML::Writer File::Temp Getopt::Long POSIX File::Basename Data::Dumper locale; do \
 		$(call check,Perl module $$module,perldoc -l $$module >& /dev/null,NOT FOUND) || rc=1; \
 	done; [[ $$rc == 0 ]] || ! echo "Some required Perl modules are missing."
 	@$(call check,XML::Twig version,perl -e 'use XML::Twig 3.32;',Portage requires XML::Twig version 3.32 or greater.)

--- a/tests/portage_utils.py/Makefile.python2
+++ b/tests/portage_utils.py/Makefile.python2
@@ -21,7 +21,7 @@ SHELL := bash
 all: open_testsuite split_testsuite
 
 
-TEMP_FILES=test* open_unittest*
+TEMP_FILES=test* open_unittest* big.gz
 include ../Makefile.incl
 
 test:
@@ -46,35 +46,35 @@ open_testsuite: open_unittest9
 # Test reading standard in.
 open_unittest0: test
 	cat $< \
-	| python3 -c "exec('from portage_utils import open\nfor line in open(\"-\"): print(line, end=\"\")')" \
+	| python2 -c "exec('from portage_utils import open\nfor line in open(\"-\"): print line,')" \
 	| diff - $<
 
 
 # Test reading a plain text file.
 open_unittest1: test
-	echo -e 'from portage_utils import open\nfor line in open("$<"): print(line, end="")' \
-	| python3 \
+	echo -e 'from portage_utils import open\nfor line in open("$<"): print line,' \
+	| python2 \
 	| diff - $<
 
 
 # Test reading a compressed gz file.
 open_unittest2: test.gz
-	echo -e 'from portage_utils import open\nfor line in open("$<", mode="rt"): print(line, end="")' \
-	| python3 \
+	echo -e 'from portage_utils import open\nfor line in open("$<"): print line,' \
+	| python2 \
 	| diff - $(basename $<)
 
 
 # Test reading from a piped command.
 open_unittest3: test.gz
-	echo -e 'from portage_utils import open\nfor line in open("zcat $< |"): print(line, end="")' \
-	| python3 \
+	echo -e 'from portage_utils import open\nfor line in open("zcat $< |"): print line,' \
+	| python2 \
 	| diff - $(basename $<)
 
 
 # Test writing to standard out.
 open_unittest4: test
 	cat $< \
-	| python3 -c "exec('from portage_utils import open\nf=open(\"-\", \"w\")\nfor line in open(\"-\"): f.write(line)')" \
+	| python2 -c "exec('from portage_utils import open\nf=open(\"-\", \"w\")\nfor line in open(\"-\"): f.write(line)')" \
 	| diff - $<
 
 
@@ -84,7 +84,7 @@ open_unittest5: open_unittest5.txt test
 	diff $+ -q
 open_unittest5.txt: test
 	cat $< \
-	| python3 -c "exec('from portage_utils import open\nf=open(\"$@\", \"w\")\nfor line in open(\"-\"): f.write(line)')"
+	| python2 -c "exec('from portage_utils import open\nf=open(\"$@\", \"w\")\nfor line in open(\"-\"): f.write(line)')"
 
 
 # Test writing to a compress gz file
@@ -93,7 +93,7 @@ open_unittest6: open_unittest6.gz test
 	zcmp $+
 open_unittest6.gz: test
 	cat $< \
-	| python3 -c "exec('from portage_utils import open\nf=open(\"$@\", \"w\")\nfor line in open(\"-\"): f.write(line)')"
+	| python2 -c "exec('from portage_utils import open\nf=open(\"$@\", \"w\")\nfor line in open(\"-\"): f.write(line)')"
 
 
 # Test writing to a compress gz file
@@ -103,13 +103,13 @@ open_unittest7: open_unittest7.gz test
 	zcmp $+
 open_unittest7.gz: test
 	cat $< \
-	| python3 -c "exec('from portage_utils import open\nf=open(\"| gzip > $@\", \"w\")\nfor line in open(\"-\"): f.write(line)')"
+	| python2 -c "exec('from portage_utils import open\nf=open(\"| gzip > $@\", \"w\")\nfor line in open(\"-\"): f.write(line)')"
 
 
 # Test writing to no file which should produce an error message.
 open_unittest8: test
 	cat $< \
-	| python3 -c "exec('from portage_utils import open\nf=open(\"\", \"w\")\nfor line in open(\"-\"): f.write(line)')" 2>&1 \
+	| python2 -c "exec('from portage_utils import open\nf=open(\"\", \"w\")\nfor line in open(\"-\"): f.write(line)')" 2>&1 \
 	| grep "Fatal error: You must provide a filename" --quiet
 
 
@@ -121,10 +121,10 @@ big.gz:
 
 # Testing partially reading a gzip file and not getting a Broken pipe message.
 open_unittest9a:  %:  big.gz
-	-python3 -c "exec('from portage_utils import open\nfor line in open(\"$<\", \"r\", False):\n  if True: break\n')" 2>&1 | egrep '(zcat|gzip): stdout: Broken pipe'
+	python2 -c "exec('from portage_utils import open\nfor line in open(\"$<\", \"r\", False):\n  if True: break\n')" 2>&1 | egrep '(zcat|gzip): stdout: Broken pipe'
 
 open_unittest9b:  %:  big.gz
-	! { set -o pipefail; python3 -c "exec('from portage_utils import open\nfor line in open(\"$<\", \"r\", True):\n  if True: break\n')" 2>&1 | egrep '(zcat|gzip): stdout: Broken pipe'; }
+	! { set -o pipefail; python2 -c "exec('from portage_utils import open\nfor line in open(\"$<\", \"r\", True):\n  if True: break\n')" 2>&1 | egrep '(zcat|gzip): stdout: Broken pipe'; }
 
 
 .PHONY: split_testsuite
@@ -134,12 +134,12 @@ split_testsuite: split_unittest1 split_unittest2
 .PHONY: split_unittest1
 split_unittest1:
 	echo "from portage_utils import split; print(split(u' a b\tc\t d\N{no-break space}dd \t\n'))" \
-	| python3 \
-	| diff - <(echo "['a', 'b', 'c', 'd\xa0dd']")
+	| python2 \
+	| diff - <(echo "[u'a', u'b', u'c', u'd\xa0dd']")
 
 # test split functionality on string containing no tokens (i.e. only whitespace)
 .PHONY: split_unittest2
 split_unittest2:
 	echo "from portage_utils import split; print(split(u'\n'))" \
-	| python3 \
+	| python2 \
 	| diff - <(echo "[]")

--- a/tests/portage_utils.py/run-test.sh
+++ b/tests/portage_utils.py/run-test.sh
@@ -10,7 +10,12 @@
 # Copyright 2011, Sa Majeste la Reine du Chef du Canada /
 # Copyright 2011, Her Majesty in Right of Canada
 
-\make clean
-\make all -B -j ${OMP_NUM_THREADS:-$(nproc)}
+# Run the test suite with Python 2.7
+make clean
+make all -B -j ${OMP_NUM_THREADS:-$(nproc)} --makefile Makefile.python2
+
+# Run the test suite with Python 3
+make clean
+make all -B -j ${OMP_NUM_THREADS:-$(nproc)}
 
 exit


### PR DESCRIPTION
It mostly already worked with Python 3, but didn't set encoding on text files, which is now pretty much required for sane processing of text images.

Duplicate the test suite so it runs both Python 2.7 and Python 3.

Also, convert strip-parallel-blank-lines.py to Python 3.
