### PR TITLE
Divide portage_utils.open() into two distinct implementations for Python 2.7 and 3

### DIFF
--- a/bin/clean_utf8.py
+++ b/bin/clean_utf8.py
@@ -232,7 +232,7 @@ def main(
         normalization_type=normalization_type,
     )
 
-    with open(str(infile), mode="r", encoding="UTF-8") as cin, open(
+    with open(str(infile), mode="r", encoding="UTF-8", newline="\n") as cin, open(
         str(outfile), mode="w", encoding="UTF-8"
     ) as cout:
         cin = map(str.strip, cin)

--- a/bin/filter-parallel.py
+++ b/bin/filter-parallel.py
@@ -74,10 +74,10 @@ def get_args():
    ops.add_argument('-le', dest="op", action=OpAction, const=Op.le, type=float,
                     metavar="THRESHOLD", help='''Keep if less than or equal to threshold''')
 
-   parser.add_argument("scores_file", type=FileType('r'),
+   parser.add_argument("scores_file", type=FileType('r', encoding="utf8"),
                        help="files to strip lines from in parallel")
 
-   parser.add_argument("in_files", nargs="+", type=FileType('r'),
+   parser.add_argument("in_files", nargs="+", type=FileType('r', encoding="utf8"),
                        help="file of scores to use for filtering")
 
    try:
@@ -91,7 +91,7 @@ def main():
    printCopyright("filter-parallel.py", 2015);
 
    cmd_args = get_args()
-   out_files = tuple(open(f.name+cmd_args.ext, 'w') for f in cmd_args.in_files)
+   out_files = tuple(open(f.name+cmd_args.ext, 'w', encoding="utf_8") for f in cmd_args.in_files)
 
    for score_line in cmd_args.scores_file:
       score = float(score_line)

--- a/bin/lines.py
+++ b/bin/lines.py
@@ -28,11 +28,7 @@ if len(sys.argv) != 3:
     sys.exit(1)
 
 ### Read arguments
-# We use latin-1 as an arbitrary 8-bit encoding for encoding-agnostic processing
-# this works with utf-8, any iso-8859-*, ascii, and every encoding where newline
-# is represented as \x0A. Using "utf_8" would make logical sense too, but it
-# would be less versatile for this utility that doesn't inspect line contents.
-encoding = "latin-1"
+encoding = "utf-8"
 numFile = open(sys.argv[1], mode="rt", encoding=encoding)
 txtFile = open(sys.argv[2], mode="rt", encoding=encoding)
 sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding=encoding)

--- a/bin/lines.py
+++ b/bin/lines.py
@@ -14,7 +14,9 @@
 # Copyright 2008, Her Majesty in Right of Canada
 
 import gzip
+import io
 import sys
+from portage_utils import open
 
 if len(sys.argv) != 3:
     sys.stderr.write("Usage: lines.py  \n\
@@ -26,14 +28,14 @@ if len(sys.argv) != 3:
     sys.exit(1)
 
 ### Read arguments
-numFile = open(sys.argv[1])
-txtFileName = sys.argv[2]
-if txtFileName[-3:] == '.gz':
-    txtFile = gzip.open(txtFileName, mode="rt")
-elif txtFileName == "-":
-    txtFile = sys.stdin
-else:
-    txtFile = open(txtFileName)
+# We use latin-1 as an arbitrary 8-bit encoding for encoding-agnostic processing
+# this works with utf-8, any iso-8859-*, ascii, and every encoding where newline
+# is represented as \x0A. Using "utf_8" would make logical sense too, but it
+# would be less versatile for this utility that doesn't inspect line contents.
+encoding = "latin-1"
+numFile = open(sys.argv[1], mode="rt", encoding=encoding)
+txtFile = open(sys.argv[2], mode="rt", encoding=encoding)
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding=encoding)
 
 ### Read line numbers
 nums = sorted([int(line.strip()) for line in numFile])
@@ -47,6 +49,7 @@ while (line != "") and (not done):
     #print("%",n1,n2)
     while n1 == n2:
         #sys.stderr.write("Line %i: %s\n" % (n2,line))
+        #sys.stdout.write(str(line))
         print(line, end='')
         if len(nums) == 0:
             done = True

--- a/bin/strip-parallel-duplicates.py
+++ b/bin/strip-parallel-duplicates.py
@@ -50,7 +50,7 @@ def get_args():
    parser.add_argument("-ext", dest="ext", type=str, default=".dedup",
                        help="extension for output files [%(default)s]")
 
-   parser.add_argument("in_files", nargs="*", type=FileType('r'),
+   parser.add_argument("in_files", nargs="*", type=FileType('r', encoding="utf-8"),
                        help="files to strip lines from in parallel")
 
    cmd_args = parser.parse_args()
@@ -65,7 +65,7 @@ def main():
    printCopyright("strip-parallel-duplicates.py", 2012)
 
    cmd_args = get_args()
-   out_files = tuple(open(f.name+cmd_args.ext, 'w') for f in cmd_args.in_files)
+   out_files = tuple(open(f.name+cmd_args.ext, 'w', encoding="utf8") for f in cmd_args.in_files)
 
    eof = False
    while True:

--- a/lib/portage_utils.py
+++ b/lib/portage_utils.py
@@ -22,7 +22,6 @@ import io
 import sys
 import argparse
 import re
-from subprocess import Popen, PIPE
 
 if sys.version_info[0] < 3:
    import __builtin__ as builtins

--- a/lib/portage_utils.py
+++ b/lib/portage_utils.py
@@ -26,20 +26,9 @@ from subprocess import Popen, PIPE
 
 if sys.version_info[0] < 3:
    import __builtin__ as builtins
-   def ignore_encoding_wrapper(fn):
-      """Wrapper for open() and Popen(), to ignore the encoding= argument,
-      which is not supported in Python 2.7."""
-      def fn_wrapper(*args, **kwargs):
-         try:
-            del kwargs["encoding"]
-         except KeyError:
-            pass
-         return fn(*args, **kwargs)
-      return fn_wrapper
-   builtin_open = ignore_encoding_wrapper(builtins.open)
-   Popen = ignore_encoding_wrapper(Popen)
 else:
-   from builtins import open as builtin_open
+   import builtins
+from subprocess import Popen, PIPE
 
 __all__ = ["printCopyright",
            "HelpAction", "VerboseAction", "VerboseMultiAction", "DebugAction",
@@ -159,8 +148,10 @@ def verbose(*args, **kwargs):
    if verbose_flag or debug_flag:
       print(*args, file=sys.stderr, **kwargs)
 
-def open(filename, mode='r', quiet=True, encoding="utf8"):
+def open_python2(filename, mode='r', quiet=True):
    """Transparently open files that are stdin, stdout, plain text, compressed or pipes.
+
+   This version of open() is optimized for python2, with its limited options.
 
    examples: open("-")
       open("file.txt")
@@ -170,13 +161,65 @@ def open(filename, mode='r', quiet=True, encoding="utf8"):
    filename: name of the file to open
    mode: open mode
    quiet:  suppress "zcat: stdout: Broken pipe" messages.
-   encoding: defaults to "utf8" for text modes (Python 3 only; ignored in Python 2.7)
+   return: file handle to the open file.
+   """
+   filename.strip()
+   #debug("open: ", filename, " in ", mode, " mode")
+   if len(filename) == 0:
+      fatal_error("You must provide a filename")
+
+   if filename == "-":
+      if mode == 'r':
+         theFile = sys.stdin
+      elif mode == 'w':
+         theFile = sys.stdout
+      else:
+         fatal_error("Unsupported mode.")
+   elif filename.endswith('|'):
+      theFile = Popen(filename[:-1], shell=True, executable="/bin/bash", stdout=PIPE).stdout
+   elif filename.startswith('|'):
+      theFile = Popen(filename[1:], shell=True, executable="/bin/bash", stdin=PIPE).stdin
+   elif filename.endswith(".gz"):
+      #theFile = gzip.open(filename, mode+'b')
+      if mode == 'r':
+         if quiet:
+            theFile = Popen(["zcat", "-f", filename], stdout=PIPE, stderr=open('/dev/null', 'w')).stdout
+         else:
+            theFile = Popen(["zcat", "-f", filename], stdout=PIPE).stdout
+      elif mode == 'w':
+         internal_file = builtins.open(filename, mode)
+         theFile = Popen(["gzip"], close_fds=True, stdin=PIPE, stdout=internal_file).stdin
+      else:
+         fatal_error("Unsupported mode for gz files.")
+   else:
+      theFile = builtins.open(filename, mode)
+
+   return theFile
+
+DEFAULT_ENCODING_VALUE=object()  # Sentinel object so we know encoding was not specified
+def open_python3(filename, mode='r', quiet=True, encoding=DEFAULT_ENCODING_VALUE, newline=None):
+   """Transparently open files that are stdin, stdout, plain text, compressed or pipes.
+
+   This version of open() is optimized for Python 3, and supports the encoding
+   and newline parameters.
+
+   examples: open("-")
+      open("file.txt", encoding="latin1")
+      open("file.gz", newline="\n")
+      open("zcat file.gz | grep a |")
+
+   filename: name of the file to open
+   mode: open mode
+   quiet:  suppress "zcat: stdout: Broken pipe" messages.
+   encoding: same as in builtins.open() but defaults to "utf8" for text modes
+   newline: same as in builtins.open()
    return: file handle to the open file.
    """
 
-   if "b" in mode:
-      # you cannot open a file in binary mode with an encoding in Python 3
-      encoding = None
+   if encoding is DEFAULT_ENCODING_VALUE:
+      encoding = None if "b" in mode else "utf-8"
+   if "b" in mode and encoding is not None:
+      fatal_error("Cannot specify encoding with binary files")
 
    filename.strip()
    #debug("open: ", filename, " in ", mode, " mode")
@@ -185,35 +228,49 @@ def open(filename, mode='r', quiet=True, encoding="utf8"):
 
    if filename == "-":
       if mode in ('r', 'rt'):
-         theFile = io.TextIOWrapper(sys.stdin.buffer, encoding=encoding)
+         theFile = builtins.open(sys.stdin.fileno(), mode, encoding=encoding, newline=newline)
+      elif mode == "rb":
+         theFile = sys.stdin
       elif mode in ('w', 'wt'):
-         theFile = io.TextIOWrapper(sys.stdout.buffer, encoding=encoding)
+         theFile = builtins.open(sys.stdout.fileno(), mode, encoding=encoding, newline=newline)
+      elif mode == "wb":
+         theFile = sys.stdout
       else:
          fatal_error("Unsupported mode.")
    elif filename.endswith('|'):
-      theFile = Popen(filename[:-1], shell=True, executable="/bin/bash", encoding=encoding,
-                      stdout=PIPE).stdout
+      theFile = Popen(filename[:-1], shell=True, executable="/bin/bash", stdout=PIPE).stdout
+      if "b" not in mode:
+         theFile = io.TextIOWrapper(theFile, encoding=encoding, newline=newline)
    elif filename.startswith('|'):
-      theFile = Popen(filename[1:], shell=True, executable="/bin/bash", encoding=encoding,
-                      stdin=PIPE).stdin
+      theFile = Popen(filename[1:], shell=True, executable="/bin/bash", stdin=PIPE).stdin
+      if "b" not in mode:
+         theFile = io.TextIOWrapper(theFile, encoding=encoding, newline=newline)
    elif filename.endswith(".gz"):
       #theFile = gzip.open(filename, mode+'b')
       if mode in ('r', 'rt', 'rb'):
          if quiet:
-            theFile = Popen(["zcat", "-f", filename], stdout=PIPE, encoding=encoding,
+            theFile = Popen(["zcat", "-f", filename], stdout=PIPE,
                             stderr=open('/dev/null', 'w')).stdout
          else:
-            theFile = Popen(["zcat", "-f", filename], stdout=PIPE, encoding=encoding).stdout
+            theFile = Popen(["zcat", "-f", filename], stdout=PIPE).stdout
+         if "b" not in mode:
+            theFile = io.TextIOWrapper(theFile, encoding=encoding, newline=newline)
       elif mode in ('w', 'wt', 'wb'):
-         internal_file = builtin_open(filename, mode, encoding=encoding)
-         theFile = Popen(["gzip"], close_fds=True, stdin=PIPE, encoding=encoding,
-                         stdout=internal_file).stdin
+         internal_file = builtins.open(filename, "wb")
+         theFile = Popen(["gzip"], close_fds=True, stdin=PIPE, stdout=internal_file).stdin
+         if "b" not in mode:
+            theFile = io.TextIOWrapper(theFile, encoding=encoding, newline=newline)
       else:
          fatal_error("Unsupported mode for gz files.")
    else:
-      theFile = builtin_open(filename, mode, encoding=encoding)
+      theFile = builtins.open(filename, mode, encoding=encoding, newline=newline)
 
    return theFile
+
+if sys.version_info[0] < 3:
+   open = open_python2
+else:
+   open = open_python3
 
 # Regular expression to match whitespace the same way that split() in
 # str_utils.cc does, i.e. sequence of spaces, tabs, and/or newlines.

--- a/lib/portage_utils.py
+++ b/lib/portage_utils.py
@@ -18,6 +18,7 @@
 
 from __future__ import print_function, unicode_literals, division, absolute_import
 
+import io
 import sys
 import argparse
 import re
@@ -184,9 +185,9 @@ def open(filename, mode='r', quiet=True, encoding="utf8"):
 
    if filename == "-":
       if mode in ('r', 'rt'):
-         theFile = sys.stdin
+         theFile = io.TextIOWrapper(sys.stdin.buffer, encoding=encoding)
       elif mode in ('w', 'wt'):
-         theFile = sys.stdout
+         theFile = io.TextIOWrapper(sys.stdout.buffer, encoding=encoding)
       else:
          fatal_error("Unsupported mode.")
    elif filename.endswith('|'):

--- a/lib/portage_utils.py
+++ b/lib/portage_utils.py
@@ -227,6 +227,11 @@ def open_python3(filename, mode='r', quiet=True, encoding=DEFAULT_ENCODING_VALUE
 
    if filename == "-":
       if mode in ('r', 'rt'):
+         # Notes on this solution: the now more standard
+         #    sys.stdin.reconfigure(encoding='utf-8')
+         # only works since Python 3.7 and we want to support older versions with
+         # this very generic library. And io.TextIOWrapper does not work on
+         # stdin/stdout (at least not with 3.6).
          theFile = builtins.open(sys.stdin.fileno(), mode, encoding=encoding, newline=newline)
       elif mode == "rb":
          theFile = sys.stdin

--- a/tests/basics/Makefile
+++ b/tests/basics/Makefile
@@ -120,6 +120,8 @@ test.lines.py:
 	diff <(lines.py <(echo $$'2\n4\n4\n10\n1') <(seq 1 20)) <(echo $$'1\n2\n4\n4\n10')
 	seq 1 20 | gzip > seq.gz
 	diff <(lines.py <(echo $$'2\n4\n4\n10\n1') seq.gz) <(echo $$'1\n2\n4\n4\n10')
+	diff <(lines.py <(echo $$'2\n4') <(echo $$'à\né\nî\nö\nù')) <(echo $$'é\nö')
+	diff <(echo $$'à\né\nî\nö\nù' | lines.py <(echo $$'2\n4') -) <(echo $$'é\nö')
 
 test: test.select-lines.py
 test.select-lines.py:

--- a/tests/clean_utf8/Makefile
+++ b/tests/clean_utf8/Makefile
@@ -20,6 +20,13 @@ include ../Makefile.incl
 
 ########################################
 # Compare a run to a reference
-test:
-	diff --brief <(clean-utf8-text.pl -wide-punct  < clean_utf8.txt) ref/clean_utf8.txt
-	diff --brief <(clean_utf8.py --phrase-table --wide-punct < clean_utf8.txt) ref/clean_utf8.txt
+test: test_perl test_python_stdin test_python_file
+
+test_perl:
+	diff <(clean-utf8-text.pl -wide-punct  < clean_utf8.txt) ref/clean_utf8.txt --brief
+
+test_python_stdin:
+	diff <(clean_utf8.py --phrase-table --wide-punct < clean_utf8.txt) ref/clean_utf8.txt --brief
+
+test_python_file:
+	diff <(clean_utf8.py --phrase-table --wide-punct clean_utf8.txt) ref/clean_utf8.txt --brief

--- a/tests/portage_utils.py/Makefile
+++ b/tests/portage_utils.py/Makefile
@@ -25,7 +25,7 @@ TEMP_FILES=test* open_unittest*
 include ../Makefile.incl
 
 test:
-	echo -e "This is a test.\nThen there is a second line.\nBut it ends on the third line." > $@
+	echo -e "This is a test àçéïôù.\nThen there is a second line.\nBut it ends on the third line." > $@
 
 test.gz: test
 	cat $< | gzip > $@

--- a/tests/portage_utils.py/Makefile
+++ b/tests/portage_utils.py/Makefile
@@ -21,7 +21,7 @@ SHELL := bash
 all: open_testsuite split_testsuite
 
 
-TEMP_FILES=test* open_unittest*
+TEMP_FILES=test* open_unittest* big.gz newlines.* outlines.*
 include ../Makefile.incl
 
 test:

--- a/tests/portage_utils.py/Makefile
+++ b/tests/portage_utils.py/Makefile
@@ -41,7 +41,7 @@ open_testsuite: open_unittest6
 open_testsuite: open_unittest7
 open_testsuite: open_unittest8
 open_testsuite: open_unittest9
-
+open_testsuite: open_newlines_encodings
 
 # Test reading standard in.
 open_unittest0: test
@@ -143,3 +143,7 @@ split_unittest2:
 	echo "from portage_utils import split; print(split(u'\n'))" \
 	| python3 \
 	| diff - <(echo "[]")
+
+# Test a multiplicity and newlines and encoding options
+open_newlines_encodings:
+	python3 $@.py | diff - ref/$@.out

--- a/tests/portage_utils.py/open_newlines_encodings.py
+++ b/tests/portage_utils.py/open_newlines_encodings.py
@@ -3,6 +3,7 @@
 import builtins
 import os
 import portage_utils
+import tempfile
 import time
 from portage_utils import open
 
@@ -27,32 +28,39 @@ for infile in "newlines.txt", "newlines.gz", "cat newlines.txt |":
     )
 
 
-for outfile, result in (
-    ("outlines.txt", "outlines.txt"),
-    ("outlines.gz", "outlines.gz"),
-    ("| cat > outlines.txt", "outlines.txt")
-):
-    for encoding in "latin1", "utf8", portage_utils.DEFAULT_ENCODING_VALUE:
-        for newline in None, "", "\n", "\r", "\r\n":
-            with open(outfile, "w", encoding=encoding, newline=newline) as f:
-                print("àéCR\rCRLF\r", file=f)
-                print("LF", file=f)
-            time.sleep(0.1)
-            with open(result, "rb") as res:
-                print(
-                    outfile,
-                    "default" if encoding is portage_utils.DEFAULT_ENCODING_VALUE else encoding,
-                    repr(newline),
-                    repr(res.read()),
-                )
-    with open(outfile, "wb") as f:
-        f.write(b"CR\rCRLF\r\nLF\n")
-    time.sleep(0.1)
-    with open(result, "rb") as res:
-        print(
-            outfile,
-            "wb",
-            repr(res.read()),
-        )
+tmp_dir_root = "/tmp" if os.path.exists("/tmp") else None  # For portability
+with tempfile.TemporaryDirectory(dir=tmp_dir_root) as tmpdirname:
+    for outfile, result in (
+        ("outlines.txt", "outlines.txt"),
+        ("outlines.gz", "outlines.gz"),
+        ("| cat > outlines.txt", "outlines.txt")
+    ):
+        if outfile == "| cat > outlines.txt":
+            outfile_path = "| cat > " + os.path.join(tmpdirname, "outlines.txt")
+        else:
+            outfile_path = os.path.join(tmpdirname, outfile)
+        result_path = os.path.join(tmpdirname, result)
+        for encoding in "latin1", "utf8", portage_utils.DEFAULT_ENCODING_VALUE:
+            for newline in None, "", "\n", "\r", "\r\n":
+                with open(outfile_path, "w", encoding=encoding, newline=newline) as f:
+                    print("àéCR\rCRLF\r", file=f)
+                    print("LF", file=f)
+                time.sleep(0.2)
+                with open(result_path, "rb") as res:
+                    print(
+                        outfile,
+                        "default" if encoding is portage_utils.DEFAULT_ENCODING_VALUE else encoding,
+                        repr(newline),
+                        repr(res.read()),
+                    )
+        with open(outfile_path, "wb") as f:
+            f.write(b"CR\rCRLF\r\nLF\n")
+        time.sleep(0.2)
+        with open(result_path, "rb") as res:
+            print(
+                outfile,
+                "wb",
+                repr(res.read()),
+            )
 
 

--- a/tests/portage_utils.py/open_newlines_encodings.py
+++ b/tests/portage_utils.py/open_newlines_encodings.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+import builtins
+import os
+import portage_utils
+import time
+from portage_utils import open
+
+with builtins.open("newlines.txt", "wt", newline="", encoding="utf8") as f:
+    f.write("TestéàûLF\nCR\rLF\nCRLF\r\nLF\n")
+os.system("gzip < newlines.txt > newlines.gz")
+
+
+for infile in "newlines.txt", "newlines.gz", "cat newlines.txt |":
+    for encoding in None, "latin1", "utf8", portage_utils.DEFAULT_ENCODING_VALUE:
+        for newline in None, "", "\n", "\r", "\r\n":
+            print(
+                infile,
+                "default" if encoding is portage_utils.DEFAULT_ENCODING_VALUE else encoding,
+                repr(newline),
+                list(open(infile, "r", encoding=encoding, newline=newline))
+            )
+    print(
+        infile,
+        "rb",
+        list(open(infile, "rb"))
+    )
+
+
+for outfile, result in (
+    ("outlines.txt", "outlines.txt"),
+    ("outlines.gz", "outlines.gz"),
+    ("| cat > outlines.txt", "outlines.txt")
+):
+    for encoding in "latin1", "utf8", portage_utils.DEFAULT_ENCODING_VALUE:
+        for newline in None, "", "\n", "\r", "\r\n":
+            with open(outfile, "w", encoding=encoding, newline=newline) as f:
+                print("àéCR\rCRLF\r", file=f)
+                print("LF", file=f)
+            time.sleep(0.1)
+            with open(result, "rb") as res:
+                print(
+                    outfile,
+                    "default" if encoding is portage_utils.DEFAULT_ENCODING_VALUE else encoding,
+                    repr(newline),
+                    repr(res.read()),
+                )
+    with open(outfile, "wb") as f:
+        f.write(b"CR\rCRLF\r\nLF\n")
+    time.sleep(0.1)
+    with open(result, "rb") as res:
+        print(
+            outfile,
+            "wb",
+            repr(res.read()),
+        )
+
+

--- a/tests/portage_utils.py/ref/open_newlines_encodings.out
+++ b/tests/portage_utils.py/ref/open_newlines_encodings.out
@@ -1,0 +1,111 @@
+newlines.txt None None ['TestéàûLF\n', 'CR\n', 'LF\n', 'CRLF\n', 'LF\n']
+newlines.txt None '' ['TestéàûLF\n', 'CR\r', 'LF\n', 'CRLF\r\n', 'LF\n']
+newlines.txt None '\n' ['TestéàûLF\n', 'CR\rLF\n', 'CRLF\r\n', 'LF\n']
+newlines.txt None '\r' ['TestéàûLF\nCR\r', 'LF\nCRLF\r', '\nLF\n']
+newlines.txt None '\r\n' ['TestéàûLF\nCR\rLF\nCRLF\r\n', 'LF\n']
+newlines.txt latin1 None ['TestÃ©Ã\xa0Ã»LF\n', 'CR\n', 'LF\n', 'CRLF\n', 'LF\n']
+newlines.txt latin1 '' ['TestÃ©Ã\xa0Ã»LF\n', 'CR\r', 'LF\n', 'CRLF\r\n', 'LF\n']
+newlines.txt latin1 '\n' ['TestÃ©Ã\xa0Ã»LF\n', 'CR\rLF\n', 'CRLF\r\n', 'LF\n']
+newlines.txt latin1 '\r' ['TestÃ©Ã\xa0Ã»LF\nCR\r', 'LF\nCRLF\r', '\nLF\n']
+newlines.txt latin1 '\r\n' ['TestÃ©Ã\xa0Ã»LF\nCR\rLF\nCRLF\r\n', 'LF\n']
+newlines.txt utf8 None ['TestéàûLF\n', 'CR\n', 'LF\n', 'CRLF\n', 'LF\n']
+newlines.txt utf8 '' ['TestéàûLF\n', 'CR\r', 'LF\n', 'CRLF\r\n', 'LF\n']
+newlines.txt utf8 '\n' ['TestéàûLF\n', 'CR\rLF\n', 'CRLF\r\n', 'LF\n']
+newlines.txt utf8 '\r' ['TestéàûLF\nCR\r', 'LF\nCRLF\r', '\nLF\n']
+newlines.txt utf8 '\r\n' ['TestéàûLF\nCR\rLF\nCRLF\r\n', 'LF\n']
+newlines.txt default None ['TestéàûLF\n', 'CR\n', 'LF\n', 'CRLF\n', 'LF\n']
+newlines.txt default '' ['TestéàûLF\n', 'CR\r', 'LF\n', 'CRLF\r\n', 'LF\n']
+newlines.txt default '\n' ['TestéàûLF\n', 'CR\rLF\n', 'CRLF\r\n', 'LF\n']
+newlines.txt default '\r' ['TestéàûLF\nCR\r', 'LF\nCRLF\r', '\nLF\n']
+newlines.txt default '\r\n' ['TestéàûLF\nCR\rLF\nCRLF\r\n', 'LF\n']
+newlines.txt rb [b'Test\xc3\xa9\xc3\xa0\xc3\xbbLF\n', b'CR\rLF\n', b'CRLF\r\n', b'LF\n']
+newlines.gz None None ['TestéàûLF\n', 'CR\n', 'LF\n', 'CRLF\n', 'LF\n']
+newlines.gz None '' ['TestéàûLF\n', 'CR\r', 'LF\n', 'CRLF\r\n', 'LF\n']
+newlines.gz None '\n' ['TestéàûLF\n', 'CR\rLF\n', 'CRLF\r\n', 'LF\n']
+newlines.gz None '\r' ['TestéàûLF\nCR\r', 'LF\nCRLF\r', '\nLF\n']
+newlines.gz None '\r\n' ['TestéàûLF\nCR\rLF\nCRLF\r\n', 'LF\n']
+newlines.gz latin1 None ['TestÃ©Ã\xa0Ã»LF\n', 'CR\n', 'LF\n', 'CRLF\n', 'LF\n']
+newlines.gz latin1 '' ['TestÃ©Ã\xa0Ã»LF\n', 'CR\r', 'LF\n', 'CRLF\r\n', 'LF\n']
+newlines.gz latin1 '\n' ['TestÃ©Ã\xa0Ã»LF\n', 'CR\rLF\n', 'CRLF\r\n', 'LF\n']
+newlines.gz latin1 '\r' ['TestÃ©Ã\xa0Ã»LF\nCR\r', 'LF\nCRLF\r', '\nLF\n']
+newlines.gz latin1 '\r\n' ['TestÃ©Ã\xa0Ã»LF\nCR\rLF\nCRLF\r\n', 'LF\n']
+newlines.gz utf8 None ['TestéàûLF\n', 'CR\n', 'LF\n', 'CRLF\n', 'LF\n']
+newlines.gz utf8 '' ['TestéàûLF\n', 'CR\r', 'LF\n', 'CRLF\r\n', 'LF\n']
+newlines.gz utf8 '\n' ['TestéàûLF\n', 'CR\rLF\n', 'CRLF\r\n', 'LF\n']
+newlines.gz utf8 '\r' ['TestéàûLF\nCR\r', 'LF\nCRLF\r', '\nLF\n']
+newlines.gz utf8 '\r\n' ['TestéàûLF\nCR\rLF\nCRLF\r\n', 'LF\n']
+newlines.gz default None ['TestéàûLF\n', 'CR\n', 'LF\n', 'CRLF\n', 'LF\n']
+newlines.gz default '' ['TestéàûLF\n', 'CR\r', 'LF\n', 'CRLF\r\n', 'LF\n']
+newlines.gz default '\n' ['TestéàûLF\n', 'CR\rLF\n', 'CRLF\r\n', 'LF\n']
+newlines.gz default '\r' ['TestéàûLF\nCR\r', 'LF\nCRLF\r', '\nLF\n']
+newlines.gz default '\r\n' ['TestéàûLF\nCR\rLF\nCRLF\r\n', 'LF\n']
+newlines.gz rb [b'Test\xc3\xa9\xc3\xa0\xc3\xbbLF\n', b'CR\rLF\n', b'CRLF\r\n', b'LF\n']
+cat newlines.txt | None None ['TestéàûLF\n', 'CR\n', 'LF\n', 'CRLF\n', 'LF\n']
+cat newlines.txt | None '' ['TestéàûLF\n', 'CR\r', 'LF\n', 'CRLF\r\n', 'LF\n']
+cat newlines.txt | None '\n' ['TestéàûLF\n', 'CR\rLF\n', 'CRLF\r\n', 'LF\n']
+cat newlines.txt | None '\r' ['TestéàûLF\nCR\r', 'LF\nCRLF\r', '\nLF\n']
+cat newlines.txt | None '\r\n' ['TestéàûLF\nCR\rLF\nCRLF\r\n', 'LF\n']
+cat newlines.txt | latin1 None ['TestÃ©Ã\xa0Ã»LF\n', 'CR\n', 'LF\n', 'CRLF\n', 'LF\n']
+cat newlines.txt | latin1 '' ['TestÃ©Ã\xa0Ã»LF\n', 'CR\r', 'LF\n', 'CRLF\r\n', 'LF\n']
+cat newlines.txt | latin1 '\n' ['TestÃ©Ã\xa0Ã»LF\n', 'CR\rLF\n', 'CRLF\r\n', 'LF\n']
+cat newlines.txt | latin1 '\r' ['TestÃ©Ã\xa0Ã»LF\nCR\r', 'LF\nCRLF\r', '\nLF\n']
+cat newlines.txt | latin1 '\r\n' ['TestÃ©Ã\xa0Ã»LF\nCR\rLF\nCRLF\r\n', 'LF\n']
+cat newlines.txt | utf8 None ['TestéàûLF\n', 'CR\n', 'LF\n', 'CRLF\n', 'LF\n']
+cat newlines.txt | utf8 '' ['TestéàûLF\n', 'CR\r', 'LF\n', 'CRLF\r\n', 'LF\n']
+cat newlines.txt | utf8 '\n' ['TestéàûLF\n', 'CR\rLF\n', 'CRLF\r\n', 'LF\n']
+cat newlines.txt | utf8 '\r' ['TestéàûLF\nCR\r', 'LF\nCRLF\r', '\nLF\n']
+cat newlines.txt | utf8 '\r\n' ['TestéàûLF\nCR\rLF\nCRLF\r\n', 'LF\n']
+cat newlines.txt | default None ['TestéàûLF\n', 'CR\n', 'LF\n', 'CRLF\n', 'LF\n']
+cat newlines.txt | default '' ['TestéàûLF\n', 'CR\r', 'LF\n', 'CRLF\r\n', 'LF\n']
+cat newlines.txt | default '\n' ['TestéàûLF\n', 'CR\rLF\n', 'CRLF\r\n', 'LF\n']
+cat newlines.txt | default '\r' ['TestéàûLF\nCR\r', 'LF\nCRLF\r', '\nLF\n']
+cat newlines.txt | default '\r\n' ['TestéàûLF\nCR\rLF\nCRLF\r\n', 'LF\n']
+cat newlines.txt | rb [b'Test\xc3\xa9\xc3\xa0\xc3\xbbLF\n', b'CR\rLF\n', b'CRLF\r\n', b'LF\n']
+outlines.txt latin1 None b'\xe0\xe9CR\rCRLF\r\nLF\n'
+outlines.txt latin1 '' b'\xe0\xe9CR\rCRLF\r\nLF\n'
+outlines.txt latin1 '\n' b'\xe0\xe9CR\rCRLF\r\nLF\n'
+outlines.txt latin1 '\r' b'\xe0\xe9CR\rCRLF\r\rLF\r'
+outlines.txt latin1 '\r\n' b'\xe0\xe9CR\rCRLF\r\r\nLF\r\n'
+outlines.txt utf8 None b'\xc3\xa0\xc3\xa9CR\rCRLF\r\nLF\n'
+outlines.txt utf8 '' b'\xc3\xa0\xc3\xa9CR\rCRLF\r\nLF\n'
+outlines.txt utf8 '\n' b'\xc3\xa0\xc3\xa9CR\rCRLF\r\nLF\n'
+outlines.txt utf8 '\r' b'\xc3\xa0\xc3\xa9CR\rCRLF\r\rLF\r'
+outlines.txt utf8 '\r\n' b'\xc3\xa0\xc3\xa9CR\rCRLF\r\r\nLF\r\n'
+outlines.txt default None b'\xc3\xa0\xc3\xa9CR\rCRLF\r\nLF\n'
+outlines.txt default '' b'\xc3\xa0\xc3\xa9CR\rCRLF\r\nLF\n'
+outlines.txt default '\n' b'\xc3\xa0\xc3\xa9CR\rCRLF\r\nLF\n'
+outlines.txt default '\r' b'\xc3\xa0\xc3\xa9CR\rCRLF\r\rLF\r'
+outlines.txt default '\r\n' b'\xc3\xa0\xc3\xa9CR\rCRLF\r\r\nLF\r\n'
+outlines.txt wb b'CR\rCRLF\r\nLF\n'
+outlines.gz latin1 None b'\xe0\xe9CR\rCRLF\r\nLF\n'
+outlines.gz latin1 '' b'\xe0\xe9CR\rCRLF\r\nLF\n'
+outlines.gz latin1 '\n' b'\xe0\xe9CR\rCRLF\r\nLF\n'
+outlines.gz latin1 '\r' b'\xe0\xe9CR\rCRLF\r\rLF\r'
+outlines.gz latin1 '\r\n' b'\xe0\xe9CR\rCRLF\r\r\nLF\r\n'
+outlines.gz utf8 None b'\xc3\xa0\xc3\xa9CR\rCRLF\r\nLF\n'
+outlines.gz utf8 '' b'\xc3\xa0\xc3\xa9CR\rCRLF\r\nLF\n'
+outlines.gz utf8 '\n' b'\xc3\xa0\xc3\xa9CR\rCRLF\r\nLF\n'
+outlines.gz utf8 '\r' b'\xc3\xa0\xc3\xa9CR\rCRLF\r\rLF\r'
+outlines.gz utf8 '\r\n' b'\xc3\xa0\xc3\xa9CR\rCRLF\r\r\nLF\r\n'
+outlines.gz default None b'\xc3\xa0\xc3\xa9CR\rCRLF\r\nLF\n'
+outlines.gz default '' b'\xc3\xa0\xc3\xa9CR\rCRLF\r\nLF\n'
+outlines.gz default '\n' b'\xc3\xa0\xc3\xa9CR\rCRLF\r\nLF\n'
+outlines.gz default '\r' b'\xc3\xa0\xc3\xa9CR\rCRLF\r\rLF\r'
+outlines.gz default '\r\n' b'\xc3\xa0\xc3\xa9CR\rCRLF\r\r\nLF\r\n'
+outlines.gz wb b'CR\rCRLF\r\nLF\n'
+| cat > outlines.txt latin1 None b'\xe0\xe9CR\rCRLF\r\nLF\n'
+| cat > outlines.txt latin1 '' b'\xe0\xe9CR\rCRLF\r\nLF\n'
+| cat > outlines.txt latin1 '\n' b'\xe0\xe9CR\rCRLF\r\nLF\n'
+| cat > outlines.txt latin1 '\r' b'\xe0\xe9CR\rCRLF\r\rLF\r'
+| cat > outlines.txt latin1 '\r\n' b'\xe0\xe9CR\rCRLF\r\r\nLF\r\n'
+| cat > outlines.txt utf8 None b'\xc3\xa0\xc3\xa9CR\rCRLF\r\nLF\n'
+| cat > outlines.txt utf8 '' b'\xc3\xa0\xc3\xa9CR\rCRLF\r\nLF\n'
+| cat > outlines.txt utf8 '\n' b'\xc3\xa0\xc3\xa9CR\rCRLF\r\nLF\n'
+| cat > outlines.txt utf8 '\r' b'\xc3\xa0\xc3\xa9CR\rCRLF\r\rLF\r'
+| cat > outlines.txt utf8 '\r\n' b'\xc3\xa0\xc3\xa9CR\rCRLF\r\r\nLF\r\n'
+| cat > outlines.txt default None b'\xc3\xa0\xc3\xa9CR\rCRLF\r\nLF\n'
+| cat > outlines.txt default '' b'\xc3\xa0\xc3\xa9CR\rCRLF\r\nLF\n'
+| cat > outlines.txt default '\n' b'\xc3\xa0\xc3\xa9CR\rCRLF\r\nLF\n'
+| cat > outlines.txt default '\r' b'\xc3\xa0\xc3\xa9CR\rCRLF\r\rLF\r'
+| cat > outlines.txt default '\r\n' b'\xc3\xa0\xc3\xa9CR\rCRLF\r\r\nLF\r\n'
+| cat > outlines.txt wb b'CR\rCRLF\r\nLF\n'

--- a/tests/portage_utils.py/run-test.sh
+++ b/tests/portage_utils.py/run-test.sh
@@ -12,13 +12,24 @@
 
 # Run the test suite with Python 2.7, but only if we find python2, since
 # PortageTextProcessing no longer actually has any python2 scripts.
+
+EXIT_CODE=
+
 if which-test.sh python2; then
    make clean
-   make all -B -j ${OMP_NUM_THREADS:-$(nproc)} --makefile Makefile.python2
+   if ! make all -B -j ${OMP_NUM_THREADS:-$(nproc)} --makefile Makefile.python2; then
+      EXIT_CODE=1
+   fi
 fi
 
 # Run the test suite with Python 3
 make clean
-make all -B -j ${OMP_NUM_THREADS:-$(nproc)}
+if ! make all -B -j ${OMP_NUM_THREADS:-$(nproc)}; then
+   EXIT_CODE=1
+fi
 
-exit
+if [[ $EXIT_CODE ]]; then
+   echo Some tests FAILED, running with either python2 or python3. Scroll up for details.
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
The Python 2 version is like open in Python 2.7, with no encoding or newline option. The caller has to deal with that themselves if they want to. open() only takes care of the magic of files/compressed files/pipes/stdin/stdout.

The Python 3 version is enriched with features that Python 3's open has: an encoding parameters, and a newline parameter. Those now have consistent behaviour, no matter how the file is opened.

In both cases, we strive to have an intuitive implementation, staying close to what the given version of Python would do.

Exception: in Python 3, when encoding= is not specified, we default to "utf8", unlike builtins.open(). While less python3-ic because good Python 3 programming requires providing the encoding on every darn open() call you make, it makes code more portable, because on Linux "utf8" ends up being the default most of the time, so testing rarely flags the problem, while on Windows "utf8" is not typically the default so we end up with code that's broken on Windows.
