### PR TITLE
feat: commenting the debugging dependency on Devel::Peek

### DIFF
--- a/lib/ULexiTools.pm
+++ b/lib/ULexiTools.pm
@@ -1466,7 +1466,7 @@ sub is_right_bracket #ch
    #use re qw(Debug All);
    if (0) {
       my $re = qr/^(<[a]>)*[])}”’´]$/;
-      use Devel::Peek;
+      #use Devel::Peek;
       print "RE=$re\n";
    }
    my $ch=shift;


### PR DESCRIPTION
This stems from the new configuration on our cluster which requires us to explicitly install that dependency which failed.
I opted to simply commenting the code because that code looks like a quick way to disable some debugging statements.

https://perldoc.perl.org/Devel::Peek